### PR TITLE
Implement atomic mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,25 @@ ws.end(function() {
 })
 ```
 
+## Atomicity
+
+By default, `fs-blob-store` doesn't make atomic writes which may lead to
+partially written files when an error occurs or if the process crashes.
+
+By using the `atomic: true` option, `fs-blob-store` will use
+[fs-write-stream-atomic](https://github.com/npm/fs-write-stream-atomic)
+which guarantees write atomicity.
+
+Note that when using that option, a key will only start to exist and be
+available for reading once its initial write is fully completed.
+
+```js
+var ws = blobs.createWriteStream({
+  key: 'some/path/file.txt',
+  atomic: true,
+})
+```
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "duplexify": "^3.2.0",
     "end-of-stream": "^1.0.0",
+    "fs-write-stream-atomic": "^1.0.8",
     "lru-cache": "^2.5.0",
     "mkdirp": "^0.5.0"
   },

--- a/test.js
+++ b/test.js
@@ -4,16 +4,52 @@ var fs = require('./')
 var os = require('os')
 var path = require('path')
 var rimraf = require('rimraf')
+var Readable = require('stream').Readable
 
-var common = {
-  setup: function(t, cb) {
-    // make a new blobs instance on every test
-    cb(null, fs(path.join(os.tmpdir(), ''+process.pid)))
-  },
-  teardown: function(t, store, blob, cb) {
-    rimraf.sync(store.path)
-    cb()
+var common = function (atomic) {
+  return {
+    setup: function(t, cb) {
+      const opts = {
+        path: path.join(os.tmpdir(), ''+process.pid),
+        atomic: atomic,
+      }
+      // make a new blobs instance on every test
+      cb(null, fs(opts))
+    },
+    teardown: function(t, store, blob, cb) {
+      rimraf.sync(store.path)
+      cb()
+    }
   }
 }
 
-tests(tape, common)
+tests(tape, common())
+
+tests(tape, common(true))
+
+tape(function (t) {
+  var store = fs({
+    path: path.join(os.tmpdir(), ''+process.pid),
+    atomic: true,
+  })
+  rimraf.sync(store.path)
+
+  var i = 0
+  var brokenReadStream = new Readable()
+  brokenReadStream._read = function () {
+    i++
+    if (i == 3) {
+      this.emit(new Error('simulated error'))
+    }
+  }
+
+  brokenReadStream.pipe(store.createWriteStream('somekey'))
+
+  setTimeout(function () {
+    store.exists('somekey', function (err, exists) {
+      if (err) return t.fail(err)
+      t.equal(exists, false)
+      t.end()
+    })
+  }, 200)
+})


### PR DESCRIPTION
By default, `fs-blob-store` doesn't make atomic writes which may lead to
partially written files when an error occurs or if the process crashes.

By using the `atomic: true` option, `fs-blob-store` will use
[fs-write-stream-atomic](https://github.com/npm/fs-write-stream-atomic)
which guarantees write atomicity.
